### PR TITLE
Compile mrbapi.c too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,10 @@ set(TIC80CORE_SRC
     ${THIRDPARTY_DIR}/duktape/src/duktape.c # TODO: link it as lib?
 )
 
+if(BUILD_MRUBY)
+	list(APPEND TIC80CORE_SRC ${TIC80CORE_DIR}/mrbapi.c)
+endif()
+
 add_library(tic80core STATIC ${TIC80CORE_SRC})
 
 if(BUILD_MRUBY)


### PR DESCRIPTION
Hi!

I wanted to give your fork a try and I needed to add this for it to compile (otherwise I'd get an error because of `getMRubyScriptConfig` not being defined).

Otherwise, test successful, everything works fine (on Manjaro Linux), at least the demo cart.